### PR TITLE
feat: Add a custom operator sample for CUDAExecutionProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ There are simple FMA(fused multiply-add) custom operator samples.
 * [pure Python sample](fma_pure_python)
 * [C++ implementation sample](fma_use_t)
 * [C++ implementation multi-domain sample](fma_multi_domain)
+* [CUDA implementation multi-domain sample](fma_multi_with_cuda)
+

--- a/fma_multi_with_cuda/CMakeLists.txt
+++ b/fma_multi_with_cuda/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.18)
+project(custom_op_fma LANGUAGES CXX)
+
+find_package(CUDA REQUIRED)
+
+if (DEFINED ONNXRUNTIME_TOP_DIR)
+	message(STATUS "ONNXRUNTIME_TOP_DIR: ${ONNXRUNTIME_TOP_DIR}")
+else ()
+	set(ONNXRUNTIME_TOP_DIR onnxruntime)
+	message(STATUS "ONNXRUNTIME_TOP_DIR: ${ONNXRUNTIME_TOP_DIR}")
+endif ()
+
+find_path(ONNXRUNTIME_INCLUDE_DIR
+	NAMES
+		onnxruntime_c_api.h
+		onnxruntime_cxx_api.h
+		onnxruntime_cxx_inline.h
+	HINTS ${ONNXRUNTIME_TOP_DIR}
+	PATH_SUFFIXES include/onnxruntime/core/session
+)
+
+if (${ONNXRUNTIME_INCLUDE_DIR} STREQUAL "ONNXRUNTIME_INCLUDE_DIR-NOTFOUND")
+    message(ERROR " ONNXRuntime not found. set ONNXRUNTIME_TOP_DIR correctly")
+else ()
+    message(STATUS "ONNXRUNTIME_INCLUDE_DIR: ${ONNXRUNTIME_INCLUDE_DIR}")
+endif ()
+
+cuda_add_library(my_custom_multi_with_cuda SHARED fma_multi_domain.cpp cuda_kernel.cu cuda_kernel.cuh)
+target_include_directories(my_custom_multi_with_cuda SYSTEM PUBLIC ${ONNXRUNTIME_INCLUDE_DIR})
+target_compile_features(my_custom_multi_with_cuda PUBLIC cxx_std_17)
+

--- a/fma_multi_with_cuda/README.md
+++ b/fma_multi_with_cuda/README.md
@@ -1,0 +1,84 @@
+# Custom operator implementation C++(different domain name corresponding with data types and CUDAExecutionProvider)
+This is a sample implementation of FAM operator with CUDA.
+
+```
+FMA = A * B + C
+
+# C is optional
+```
+
+# pre-requirements
+* numpy
+* onnx
+* onnxruntime-gpu (NEED CUDAExecutionProvider)
+* git > 2.25
+* cmake >= 3.18
+
+# files
+* CMakeLists.txt
+  - cmake file to make so
+* cuda_kernel.cu
+  - CUDA kernel implementation of custom operator
+* cuda_kernel.cuh
+  - header file of CUDA host functions
+* fma_multi_domain.cpp
+  - C++ implementation of custom operator
+* demo_fma.py
+  - script which demonstrate how to inference ONNX model(has custom operator) with CUDAExecutionProvider
+* docker/Dockerfile
+  - Dockerfile of ONNXRuntime with CUDAExecutionProvider for Jetson
+
+# Jetson Environment
+
+docker command sample
+```
+cd runtime_custom_op/fma_multi_with_cuda/docker
+docker build --tag cuda_ep_base .
+
+# run container with fma_multi_with_cuda directory is mounted to /work
+docker run -it --rm --name custom_op_demo --net=host --runtime nvidia --shm-size=1g -e DISPLAY=$DISPLAY -v ~/runtime_custom_op/fma_multi_with_cuda:/work -v /tmp/.X11-unix/:/tmp/.X11-unix cuda_ep_base
+```
+
+# build
+1. check onnxruntime package version
+```
+python3 -c "import onnxruntime as ort; print(ort.__version__)"
+```
+
+2. checkout onnxruntime headers
+```
+cd
+git clone --filter=blob:none --no-checkout https://github.com/microsoft/onnxruntime.git
+cd onnxruntime
+git sparse-checkout init --cone
+git sparse-checkout set include/onnxruntime/core/session
+git checkout -b 1.13.1 v1.13.1
+```
+match tag version with onnxruntime package version
+
+!CAUTION!
+
+docker/Dockerfile's onnxruntime is not specify version. so if you use docker/Dockerfile, checkout latest version at main branch.
+
+3. make
+```
+# change current to fma_multi_with_cuda dir.(in docker case, /work)
+cd fma_multi_with_cuda
+
+mkdir build
+cd build
+cmake -DONNXRUNTIME_TOP_DIR=~/onnxruntime ..
+make
+```
+
+# run
+```
+cd fma_multi_with_cuda
+cp build/*my_custom_multi_with_cuda.* .
+python3 demo_fma.py
+```
+
+# known limitation
+* There can't has operator overload
+  - only one op_type name can register at one domain
+

--- a/fma_multi_with_cuda/cuda_kernel.cu
+++ b/fma_multi_with_cuda/cuda_kernel.cu
@@ -1,0 +1,75 @@
+#include <cuda_runtime_api.h>
+#include "cuda_kernel.cuh"
+
+
+namespace
+{
+
+template <typename T>
+__global__ void fma_kernel(T* out, const T* A, const T* B, const T* C, int offset)
+{
+	int index = blockIdx.x * blockDim.x + threadIdx.x + offset;
+
+	out[index] = A[index] * B[index] + C[index];
+}
+
+template <typename T>
+__global__ void fma_kernel(T* out, const T* A, const T* B, int offset)
+{
+	int index = blockIdx.x * blockDim.x + threadIdx.x + offset;
+
+	out[index] = A[index] * B[index];
+}
+
+
+// Maximum number of threads per block
+constexpr int MAX_THREADS = 1024;
+
+}		// namespace
+
+
+namespace custom_kernel
+{
+
+template <typename T>
+void fma_core(T* out, const T* A, const T* B, const T* C, size_t element_count, cudaStream_t stream)
+{
+	int offset = 0;
+	int num_blocks = element_count / MAX_THREADS;
+	int num_threads = MAX_THREADS;
+	fma_kernel<T><<<num_blocks, num_threads, 0, stream>>>(out, A, B, C, offset);
+
+	if (element_count % MAX_THREADS) {
+		offset = num_blocks * MAX_THREADS;
+		num_blocks = 1;
+		num_threads = element_count % MAX_THREADS;
+		fma_kernel<T><<<num_blocks, num_threads, 0, stream>>>(out, A, B, C, offset);
+	}
+}
+
+template <typename T>
+void fma_core(T* out, const T* A, const T* B, size_t element_count, cudaStream_t stream)
+{
+	int offset = 0;
+	int num_blocks = element_count / MAX_THREADS;
+	int num_threads = MAX_THREADS;
+	fma_kernel<T><<<num_blocks, num_threads, 0, stream>>>(out, A, B, offset);
+
+	if (element_count % MAX_THREADS) {
+		offset = num_blocks * MAX_THREADS;
+		num_blocks = 1;
+		num_threads = element_count % MAX_THREADS;
+		fma_kernel<T><<<num_blocks, num_threads, 0, stream>>>(out, A, B, offset);
+	}
+}
+
+
+// explicit instantiation
+template void fma_core<float>(float*, const float*, const float*, const float*, size_t, cudaStream_t);
+template void fma_core<double>(double*, const double*, const double*, const double*, size_t, cudaStream_t);
+
+template void fma_core<float>(float*, const float*, const float*, size_t, cudaStream_t);
+template void fma_core<double>(double*, const double*, const double*, size_t, cudaStream_t);
+
+}	// custom_kernel
+

--- a/fma_multi_with_cuda/cuda_kernel.cuh
+++ b/fma_multi_with_cuda/cuda_kernel.cuh
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace custom_kernel
+{
+
+template <typename T>
+void fma_core(T* out, const T* A, const T* B, const T* C, size_t element_count, cudaStream_t stream);
+
+template <typename T>
+void fma_core(T* out, const T* A, const T* B, size_t element_count, cudaStream_t stream);
+
+}	// namespace custom_kernel
+

--- a/fma_multi_with_cuda/demo_fma.py
+++ b/fma_multi_with_cuda/demo_fma.py
@@ -1,0 +1,59 @@
+import onnx
+import numpy as np
+import onnxruntime as ort
+
+
+print('FMA custom op sample with CUDA')
+
+# load custom op library
+option = ort.SessionOptions()
+option.register_custom_ops_library('./libmy_custom_multi_with_cuda.so')
+# specify execution providers which you use
+providers = ['CUDAExecutionProvider']
+# opset v17 at default domain
+opsets = [onnx.helper.make_opsetid('', 17)]
+
+# ONNX model creation
+inputs = [
+    onnx.helper.make_tensor_value_info('A', onnx.TensorProto.FLOAT, [1]),
+    onnx.helper.make_tensor_value_info('B', onnx.TensorProto.FLOAT, [1]),
+    onnx.helper.make_tensor_value_info('C', onnx.TensorProto.FLOAT, [1]),
+]
+outputs = [onnx.helper.make_tensor_value_info('out', onnx.TensorProto.FLOAT, [1])]
+nodes = [onnx.helper.make_node('Fma', ['A', 'B', 'C'], ['out'], domain='my_ops.float')]
+graph = onnx.helper.make_graph(nodes, 'fma', inputs, outputs)
+model = onnx.helper.make_model(graph, opset_imports=opsets)
+
+# create session object with custom op, CUDAExecutionProvider
+sess = ort.InferenceSession(model.SerializeToString(), option, providers)
+
+# input data
+A = np.ones([1], dtype=np.float32)
+B = np.ones([1], dtype=np.float32)
+C = np.ones([1], dtype=np.float32)
+
+# inference
+results = sess.run(None, {'A': A, 'B': B, 'C': C})
+
+# print result
+print(f'fp32: {A} * {B} + {C} -> {results[0]}')
+
+
+# fp64 version
+inputs = [
+    onnx.helper.make_tensor_value_info('A', onnx.TensorProto.DOUBLE, [1]),
+    onnx.helper.make_tensor_value_info('B', onnx.TensorProto.DOUBLE, [1]),
+    onnx.helper.make_tensor_value_info('C', onnx.TensorProto.DOUBLE, [1]),
+]
+outputs = [onnx.helper.make_tensor_value_info('out', onnx.TensorProto.DOUBLE, [1])]
+nodes = [onnx.helper.make_node('Fma', ['A', 'B', 'C'], ['out'], domain='my_ops.double')]
+graph = onnx.helper.make_graph(nodes, 'fma', inputs, outputs)
+model = onnx.helper.make_model(graph, opset_imports=opsets)
+
+sess = ort.InferenceSession(model.SerializeToString(), option, providers)
+A = np.ones([1], dtype=np.float64)
+B = np.ones([1], dtype=np.float64)
+C = np.ones([1], dtype=np.float64)
+results = sess.run(None, {'A': A, 'B': B, 'C': C})
+print(f'fp64: {A} * {B} + {C} -> {results[0]}')
+

--- a/fma_multi_with_cuda/docker/Dockerfile
+++ b/fma_multi_with_cuda/docker/Dockerfile
@@ -1,0 +1,55 @@
+# for Jetson devices(need CUDA, ubuntu20.04)
+FROM nvcr.io/nvidia/l4t-pytorch:r35.1.0-pth1.13-py3
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+    build-essential \
+    software-properties-common \
+    libopenblas-dev \
+    libpython3.8-dev \
+    python3-pip \
+    python3-dev \
+    python3-setuptools \
+    python3-wheel \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    sudo \
+    wget \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+# CMake
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1-linux-aarch64.sh \
+ && chmod +x ./cmake-*.sh \
+ && bash ./cmake-*.sh --prefix=/usr/local --exclude-subdir --skip-license \
+ && rm ./cmake-*.sh
+
+# onnxruntime-gpu, onnx
+RUN git clone -b v1.13.1 --recursive https://github.com/microsoft/onnxruntime \
+ && cd onnxruntime \
+ && CUDACXX=/usr/local/cuda/bin/nvcc ./build.sh --config Release --update --build --parallel --build_wheel \
+    --use_tensorrt --cuda_home /usr/local/cuda --cudnn_home /usr/lib/aarch64-linux-gnu \
+    --tensorrt_home /usr/lib/aarch64-linux-gnu \
+ && python3 -m pip install build/Linux/Release/dist/onnxruntime_gpu-*.whl \
+ && cd .. \
+ && rm -rf onnxruntime \
+ && python3 -m pip install onnx \
+ && rm -rf ~/.cache/pip
+
+# for Jetson environment only
+ENV LANG=en_US.UTF-8
+ARG uid=1000
+ARG gid=1000
+RUN groupadd -r -f -g ${gid} nvidia \
+ && useradd -o -r -l -u ${uid} -g ${gid} -ms /bin/bash nvidia \
+ && usermod -aG sudo nvidia \
+ && usermod -aG video nvidia \
+ && echo 'nvidia:nvidia' | chpasswd \
+ && touch /home/nvidia/.bash_profile \
+ && chown nvidia:nvidia /home/nvidia/.bash_profile \
+ && echo 'export LANG=en_US.UTF-8' >> /home/nvidia/.bash_profile \
+ && echo 'export PATH=$PATH:/usr/local/cuda/bin' >> /home/nvidia/.bash_profile \
+ && echo 'export PATH=$PATH:/home/nvidia/.local/bin' >> /home/nvidia/.bash_profile \
+ && echo 'export LD_LIBRARY_PATH=/usr/local/cuda/lib64' >> /home/nvidia/.bash_profile \
+ && echo 'export TERM=xterm-256color' >> /home/nvidia/.bash_profile \
+ && echo 'export PS1="\[\e[31m\]container\[\e[0m\]:\u@\W\$ "' >> /home/nvidia/.bash_profile

--- a/fma_multi_with_cuda/fma_multi_domain.cpp
+++ b/fma_multi_with_cuda/fma_multi_domain.cpp
@@ -1,0 +1,166 @@
+#include <cassert>
+#include <vector>
+#include <string>
+#include <string_view>
+#include <tuple>	// forward_as_tuple
+#include <memory>	// unique_ptr
+#include <mutex>	// lock_guard, mutex
+
+#define ORT_API_MANUAL_INIT
+#include <onnxruntime_c_api.h>
+#include <onnxruntime_cxx_api.h>
+#undef ORT_API_MANUAL_INIT
+
+#include "cuda_kernel.cuh"
+
+// internal linkage
+namespace {
+
+// kernel of FMA operation
+template <typename T>
+struct FmaKernel {
+	FmaKernel(const OrtApi &api):ort_(api) {}
+
+	void Compute(OrtKernelContext* context) {
+		assert(ort_.KernelContext_GetInputCount(context) >= 2);
+
+		const auto input_a = ort_.KernelContext_GetInput(context, 0);
+		const auto input_b = ort_.KernelContext_GetInput(context, 1);
+
+		auto info_a = ort_.GetTensorTypeAndShape(input_a);
+		auto shape_a = ort_.GetTensorShape(info_a);
+		auto element_count = ort_.GetTensorShapeElementCount(info_a);
+		ort_.ReleaseTensorTypeAndShapeInfo(info_a);
+		auto info_b = ort_.GetTensorTypeAndShape(input_b);
+		auto shape_b = ort_.GetTensorShape(info_b);
+		ort_.ReleaseTensorTypeAndShapeInfo(info_b);
+		assert(shape_a == shape_b);
+
+		auto output_0 = ort_.KernelContext_GetOutput(context, 0, shape_a.data(), shape_a.size());
+
+		// get device memories
+		auto ptr_a = ort_.GetTensorData<T>(input_a);
+		auto ptr_b = ort_.GetTensorData<T>(input_b);
+		auto ptr_0 = ort_.GetTensorMutableData<T>(output_0);
+
+		// get CUDA stream ID
+		cudaStream_t stream = reinterpret_cast<cudaStream_t>(ort_.KernelContext_GetGPUComputeStream(context));
+
+		if (ort_.KernelContext_GetInputCount(context) > 2) {
+			const auto input_c = ort_.KernelContext_GetInput(context, 2);
+			auto info_c = ort_.GetTensorTypeAndShape(input_c);
+			auto shape_c = ort_.GetTensorShape(info_c);
+			ort_.ReleaseTensorTypeAndShapeInfo(info_c);
+			assert(shape_a == shape_b && shape_a == shape_c);
+			auto ptr_c = ort_.GetTensorData<T>(input_c);
+
+			// call CUDA host function
+			custom_kernel::fma_core<T>(ptr_0, ptr_a, ptr_b, ptr_c, element_count, stream);
+		} else {
+			custom_kernel::fma_core<T>(ptr_0, ptr_a, ptr_b, element_count, stream);
+		}
+	}
+
+private:
+	Ort::CustomOpApi ort_;
+};
+
+// FMA operator
+template <typename T>
+struct CustomOpFma : Ort::CustomOpBase<CustomOpFma<T>, FmaKernel<T>> {
+	void* CreateKernel(const OrtApi &api, const OrtKernelInfo* info) const {
+		return new FmaKernel<T>(api);
+	}
+	const char* GetName() const {
+		// same as op_type
+		return "Fma";
+	}
+	const char* GetExecutionProviderType() const {
+		return "CUDAExecutionProvider";
+	}
+	ONNXTensorElementDataType GetInputType(size_t index) const {
+		return Ort::TypeToTensorType<T>::type;
+	}
+	size_t GetInputTypeCount() const {
+		return 3;
+	}
+	OrtCustomOpInputOutputCharacteristic GetInputCharacteristic(size_t index) const {
+		if (index > 1) {
+			// input[2] is optional argument
+			return OrtCustomOpInputOutputCharacteristic::INPUT_OUTPUT_OPTIONAL;
+		}
+		return OrtCustomOpInputOutputCharacteristic::INPUT_OUTPUT_REQUIRED;
+	}
+	ONNXTensorElementDataType GetOutputType(size_t index) const {
+		return Ort::TypeToTensorType<T>::type;
+	}
+	size_t GetOutputTypeCount() const {
+		return 1;
+	}
+};
+
+
+struct DomainDeleter {
+	DomainDeleter(const OrtApi* api):api_(api) {}
+	void operator() (OrtCustomOpDomain* domain) const {
+		api_->ReleaseCustomOpDomain(domain);
+	}
+
+private:
+	const OrtApi* api_;
+};
+
+using domain_ptr_type = std::unique_ptr<OrtCustomOpDomain, DomainDeleter>;
+std::vector<domain_ptr_type> domain_registry;
+void register_domain(OrtCustomOpDomain* domain, const OrtApi* api) {
+	static std::mutex m;
+
+	std::lock_guard<std::mutex> lock(m);
+
+	domain_registry.emplace_back(domain_ptr_type(domain, DomainDeleter(api)));
+}
+
+
+constexpr std::string_view domain_base = "my_ops";
+CustomOpFma<float> op_fma_float;	// float type FMA operator
+CustomOpFma<double> op_fma_double;	// double type FMA operator
+
+// domain name and corresponding operator
+std::vector<std::tuple<std::string, OrtCustomOp*>> op_list = {
+	std::forward_as_tuple(std::string(domain_base) + "." + "float", &op_fma_float),
+	std::forward_as_tuple(std::string(domain_base) + "." + "double", &op_fma_double),
+};
+
+}	// namespace
+
+
+// external linkage
+
+extern "C" {
+
+// call from SessionOptions.register_custom_ops_library()
+OrtStatus* ORT_API_CALL RegisterCustomOps(OrtSessionOptions* options, const OrtApiBase* api_base) {
+	const OrtApi* ort_api = api_base->GetApi(ORT_API_VERSION);
+	OrtStatus* status = nullptr;
+
+	for (const auto& [domain_name, op] : op_list) {
+		OrtCustomOpDomain* domain = nullptr;
+		if (status = ort_api->CreateCustomOpDomain(domain_name.c_str(), &domain)) {
+			return status;
+		}
+
+		register_domain(domain, ort_api);
+
+		if (status = ort_api->CustomOpDomain_Add(domain, op)) {
+			return status;
+		}
+
+		if (status = ort_api->AddCustomOpDomain(options, domain)) {
+			return status;
+		}
+	}
+
+	return status;
+}
+
+}	// extern "C"


### PR DESCRIPTION
related issue #1

Add a new custom operator sample for CUDAExecutionProvider.

# Contents
* sample implementation codes
  - cuda_kernel.cu, cuh
  - fma_multi_domain.cpp
* demo codes
  - demo_fma.py
* develop codes
  - CMakeLists.txt
  - docker/Dockerfile (only for Jetson)

# Reference
* [ONNX Runtime Execution Providers](https://onnxruntime.ai/docs/execution-providers/) Official
* [Custom Operator Implementation code](https://github.com/microsoft/onnxruntime/blob/e5ed47a11dd53bf87791d137307c2a898184087f/onnxruntime/test/testdata/custom_op_library/custom_op_library.cc) Official
* [CUDA implementation code](https://github.com/microsoft/onnxruntime/blob/e5ed47a11dd53bf87791d137307c2a898184087f/onnxruntime/test/shared_lib/cuda_ops.cu) Official
* [README.md](https://github.com/maminus/runtime_custom_op/blob/2f95449087d52edcadbe3b959b96de3eded54243/fma_multi_with_cuda/README.md)

# Environment of validation
* Jetson AGX Orin dev kit
* JetPack 5.0.2

# Validation items
* build custom library in the docker environment
* run demo_fma.py, and check result visually
